### PR TITLE
Telemetry kafka es sink

### DIFF
--- a/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
+++ b/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
@@ -24,8 +24,6 @@ import org.egov.infra.indexer.web.contract.Mapping;
 import org.egov.infra.indexer.web.contract.Mapping.ConfigKeyEnum;
 import org.egov.infra.indexer.web.contract.ReindexRequest;
 import org.egov.infra.indexer.web.contract.ReindexResponse;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -247,14 +245,8 @@ public class ReindexService {
 			public void run() {
 				if (threadRun) {
 					try {
-
-//						indexerService.esIndexer(reindexRequest.getReindexTopic(),
-//								mapper.writeValueAsString(requestToReindex));
-                        List<Object> hits = (List<Object>) ( (Map<String, Object>) requestToReindex).get("hits");
-                        for(Object hit: hits) {
-                            log.info(hit.toString());
-                            indexerProducer.producer("telemetry-unbundled-messages", hit);
-                        }
+						indexerService.esIndexer(reindexRequest.getReindexTopic(),
+								mapper.writeValueAsString(requestToReindex));
 						recordsIndexed += resultSize;
 						log.info("Records indexed: " + recordsIndexed);
 					} catch (Exception e) {

--- a/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
+++ b/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
@@ -24,6 +24,8 @@ import org.egov.infra.indexer.web.contract.Mapping;
 import org.egov.infra.indexer.web.contract.Mapping.ConfigKeyEnum;
 import org.egov.infra.indexer.web.contract.ReindexRequest;
 import org.egov.infra.indexer.web.contract.ReindexResponse;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -245,9 +247,14 @@ public class ReindexService {
 			public void run() {
 				if (threadRun) {
 					try {
+
 //						indexerService.esIndexer(reindexRequest.getReindexTopic(),
 //								mapper.writeValueAsString(requestToReindex));
-                        indexerProducer.producer(reindexRequest.getReindexTopic(), requestToReindex);
+                        List<Object> hits = (List<Object>) ( (Map<String, Object>) requestToReindex).get("hits");
+                        for(Object hit: hits) {
+                            log.info(hit.toString());
+                            indexerProducer.producer("telemetry-unbundled-messages", hit);
+                        }
 						recordsIndexed += resultSize;
 						log.info("Records indexed: " + recordsIndexed);
 					} catch (Exception e) {

--- a/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
+++ b/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
@@ -247,7 +247,7 @@ public class ReindexService {
 					try {
 //						indexerService.esIndexer(reindexRequest.getReindexTopic(),
 //								mapper.writeValueAsString(requestToReindex));
-                        indexerProducer.producer(reindexRequest.getReindexTopic(), mapper.writeValueAsString(requestToReindex));
+                        indexerProducer.producer(reindexRequest.getReindexTopic(), requestToReindex);
 						recordsIndexed += resultSize;
 						log.info("Records indexed: " + recordsIndexed);
 					} catch (Exception e) {

--- a/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
+++ b/core/egov-indexer/src/main/java/org/egov/infra/indexer/service/ReindexService.java
@@ -245,8 +245,9 @@ public class ReindexService {
 			public void run() {
 				if (threadRun) {
 					try {
-						indexerService.esIndexer(reindexRequest.getReindexTopic(),
-								mapper.writeValueAsString(requestToReindex));
+//						indexerService.esIndexer(reindexRequest.getReindexTopic(),
+//								mapper.writeValueAsString(requestToReindex));
+                        indexerProducer.producer(reindexRequest.getReindexTopic(), mapper.writeValueAsString(requestToReindex));
 						recordsIndexed += resultSize;
 						log.info("Records indexed: " + recordsIndexed);
 					} catch (Exception e) {

--- a/core/egov-indexer/src/main/resources/application.properties
+++ b/core/egov-indexer/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.context-path=/egov-indexer
 app.timezone=UTC
 
 #elasticSearch index api
-egov.infra.indexer.host=http://localhost:9200/
+egov.infra.indexer.host=https://egov-micro-dev.egovernments.org/elasticsearch
 egov.infra.indexer.name=/egov-indexer/index
 
 spring.datasource.driver-class-name=org.postgresql.Driver
@@ -81,8 +81,7 @@ egov.pt.search.endpoint=/pt-services-v2/property/_search
 
 # file path for loading yamls
 #egov.indexer.yml.repo.path=https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/watercharges-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/swm-service-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/asset-service-maha.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/lcms-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/inventory-service-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/rainmaker-pgr-indexer.yml
-egov.indexer.yml.repo.path=file://home/rushanag/github/egov-services/core/egov-indexer/src/main/resources/egov\
-  -telemetry-indexer.yml
+egov.indexer.yml.repo.path=file://home/vishal/git/master/egov-services/core/egov-indexer/src/main/resources/rainmaker-pt-indexer.yml
 
 
 logging.pattern.console=%clr(%X{CORRELATION_ID:-}) %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}

--- a/core/egov-indexer/src/main/resources/application.properties
+++ b/core/egov-indexer/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.context-path=/egov-indexer
 app.timezone=UTC
 
 #elasticSearch index api
-egov.infra.indexer.host=https://egov-micro-dev.egovernments.org/elasticsearch
+egov.infra.indexer.host=http://localhost:9200/
 egov.infra.indexer.name=/egov-indexer/index
 
 spring.datasource.driver-class-name=org.postgresql.Driver
@@ -81,7 +81,8 @@ egov.pt.search.endpoint=/pt-services-v2/property/_search
 
 # file path for loading yamls
 #egov.indexer.yml.repo.path=https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/watercharges-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/swm-service-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/asset-service-maha.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/lcms-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/inventory-service-indexer.yml,https://raw.githubusercontent.com/egovernments/egov-services/master/core/egov-indexer/src/main/resources/rainmaker-pgr-indexer.yml
-egov.indexer.yml.repo.path=file://home/vishal/git/master/egov-services/core/egov-indexer/src/main/resources/rainmaker-pt-indexer.yml
+egov.indexer.yml.repo.path=file://home/rushanag/github/egov-services/core/egov-indexer/src/main/resources/egov\
+  -telemetry-indexer.yml
 
 
 logging.pattern.console=%clr(%X{CORRELATION_ID:-}) %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}

--- a/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
+++ b/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
@@ -2,15 +2,15 @@ ServiceMaps:
  serviceName: Telemetry
  version: 1.0.0
  mappings:
-  - topic: telemetry-final-messages
-    configKey: INDEX
-    indexes:
-    - name: telemetryindex-v1
-      type: general
-      id: $.mid
-      isBulk: true
-      jsonPath: $.events.*
-      timeStampField: $.ets
+#  - topic: telemetry-final-messages
+#    configKey: INDEX
+#    indexes:
+#    - name: telemetryindex-v1
+#      type: general
+#      id: $.mid
+#      isBulk: true
+#      jsonPath: $.events.*
+#      timeStampField: $.ets
       
   - topic: telemetry-unbundled-messages
     configKey: REINDEX

--- a/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
+++ b/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
@@ -12,7 +12,7 @@ ServiceMaps:
       jsonPath: $.events.*
       timeStampField: $.ets
       
-  - topic: telemetry-reindex
+  - topic: telemetry-unbundled-messages
     configKey: REINDEX
     indexes:
     - name: telemetryindex-v1.1
@@ -20,7 +20,6 @@ ServiceMaps:
       id: $.mid
       isBulk: true
       jsonPath: $.hits
-      timeStampField: $.ets
       
   - topic: batch-telemetry
     configKey: INDEX

--- a/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
+++ b/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
@@ -12,7 +12,7 @@ ServiceMaps:
 #      jsonPath: $.events.*
 #      timeStampField: $.ets
       
-  - topic: telemetry-unbundled-messages
+  - topic: telemetry-unbundled-messages-test
     configKey: REINDEX
     indexes:
     - name: telemetryindex-v1.1

--- a/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
+++ b/core/egov-indexer/src/main/resources/egov-telemetry-indexer.yml
@@ -2,17 +2,17 @@ ServiceMaps:
  serviceName: Telemetry
  version: 1.0.0
  mappings:
-#  - topic: telemetry-final-messages
-#    configKey: INDEX
-#    indexes:
-#    - name: telemetryindex-v1
-#      type: general
-#      id: $.mid
-#      isBulk: true
-#      jsonPath: $.events.*
-#      timeStampField: $.ets
+  - topic: telemetry-final-messages
+    configKey: INDEX
+    indexes:
+    - name: telemetryindex-v1
+      type: general
+      id: $.mid
+      isBulk: true
+      jsonPath: $.events.*
+      timeStampField: $.ets
       
-  - topic: telemetry-unbundled-messages-test
+  - topic: telemetry-reindex
     configKey: REINDEX
     indexes:
     - name: telemetryindex-v1.1
@@ -20,7 +20,8 @@ ServiceMaps:
       id: $.mid
       isBulk: true
       jsonPath: $.hits
-      
+      timeStampField: $.ets
+
   - topic: batch-telemetry
     configKey: INDEX
     indexes:

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/application/BatchApplication.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/application/BatchApplication.java
@@ -41,7 +41,7 @@ public class BatchApplication {
 
         log.info("Total Sessions: " + SessionProcessor.totalSessionCounter);
 
-        SessionProcessor.closeKafka();
+        SessionProcessor.closeSessionProcessor();
 
     }
 

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/config/AppProperties.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/config/AppProperties.java
@@ -30,7 +30,8 @@ public class AppProperties {
 
     public AppProperties() {
 
-        sessionTimeout = TimeUnit.MINUTES.toMillis(Long.valueOf(System.getenv("SESSION_TIMEOUT")));
+        if(System.getenv("SESSION_TIMEOUT") != null)
+            sessionTimeout = TimeUnit.MINUTES.toMillis(Long.valueOf(System.getenv("SESSION_TIMEOUT")));
 
         kafkaBootstrapServer = System.getenv("KAFKA_BOOTSTRAP_SERVER_CONFIG");
         outputKafkaTopic = System.getenv("KAFKA_OUTPUT_TOPIC");
@@ -43,29 +44,35 @@ public class AppProperties {
         inputTelemetryIndex = System.getenv("ES_INPUT_TELEMETRY_INDEX");
         outputTelemetrySessionsIndex = System.getenv("ES_OUTPUT_TELEMETRY_BATCH_INDEX");
 
+        Properties properties = new Properties();
 
+        try {
+            properties.load(getClass().getClassLoader().getResourceAsStream("application.properties"));
+        } catch (IOException e) {
+            log.error("Error reading application.properties");
+        }
 
-//        Properties properties = new Properties();
-//
-//        try {
-//            properties.load(getClass().getClassLoader().getResourceAsStream("application.properties"));
-//        } catch (IOException e) {
-//            log.error("Error reading application.properties");
-//        }
-//
-//        sessionTimeout = TimeUnit.MINUTES.toMillis(Long.valueOf(properties.getProperty("SESSION_TIMEOUT")));
-//
-//        kafkaBootstrapServer = properties.getProperty("KAFKA_BOOTSTRAP_SERVER_CONFIG");
-//        outputKafkaTopic = properties.getProperty("KAFKA_OUTPUT_TOPIC");
-//
-//        esURL = properties.getProperty("ES_URL");
-//        esHost = properties.getProperty("ES_HOST");
-//        esPort = properties.getProperty("ES_PORT");
-//        esNodesWANOnly = properties.getProperty("ES_NODE_WAN_ONLY");
-//
-//        inputTelemetryIndex = properties.getProperty("ES_INPUT_TELEMETRY_INDEX");
-//        outputTelemetrySessionsIndex = properties.getProperty("ES_OUTPUT_TELEMETRY_BATCH_INDEX");
+        if(sessionTimeout == null)
+            sessionTimeout = TimeUnit.MINUTES.toMillis(Long.valueOf(properties.getProperty("SESSION_TIMEOUT")));
 
+        if(kafkaBootstrapServer == null)
+            kafkaBootstrapServer = properties.getProperty("KAFKA_BOOTSTRAP_SERVER_CONFIG");
+        if(outputKafkaTopic == null)
+            outputKafkaTopic = properties.getProperty("KAFKA_OUTPUT_TOPIC");
+
+        if(esURL == null)
+            esURL = properties.getProperty("ES_URL");
+        if(esHost == null)
+            esHost = properties.getProperty("ES_HOST");
+        if(esPort == null)
+            esPort = properties.getProperty("ES_PORT");
+        if(esNodesWANOnly == null)
+            esNodesWANOnly = properties.getProperty("ES_NODE_WAN_ONLY");
+
+        if(inputTelemetryIndex == null)
+            inputTelemetryIndex = properties.getProperty("ES_INPUT_TELEMETRY_INDEX");
+        if(outputTelemetrySessionsIndex == null)
+            outputTelemetrySessionsIndex = properties.getProperty("ES_OUTPUT_TELEMETRY_BATCH_INDEX");
 
     }
 

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/constants/TelemetryConstants.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/constants/TelemetryConstants.java
@@ -10,4 +10,8 @@ public class TelemetryConstants {
 
     public final static String commonUserType = "Common";
 
+    public final static String sessionTypeName = "session";
+
+    public final static String pathTypeName = "path";
+
 }

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/InputNode.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/InputNode.java
@@ -1,0 +1,17 @@
+package org.egov.batchtelemetry.models;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class InputNode {
+
+    private String nodeName;
+
+    private String url;
+
+}

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/InputPath.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/InputPath.java
@@ -1,0 +1,19 @@
+package org.egov.batchtelemetry.models;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class InputPath {
+
+    private String pathId;
+
+    private List<InputNode> inputNodes;
+
+}

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/Node.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/Node.java
@@ -1,0 +1,33 @@
+package org.egov.batchtelemetry.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class Node {
+
+    private String nodeId;
+
+    @JsonProperty("@timestamp")
+    private String timestamp;
+
+    private String type;
+
+    private String pathId;
+
+    private String sessionId;
+
+    private String nodeName;
+
+    private String url;
+
+    private Long nodeTime;
+
+    private Long timeSpent;
+
+}

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/Session.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/models/Session.java
@@ -10,6 +10,8 @@ import lombok.*;
 @NoArgsConstructor
 public class Session {
 
+    private String type;
+
     private String sessionId;
 
     @JsonProperty("@timestamp")

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/processor/PathProcessor.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/processor/PathProcessor.java
@@ -1,0 +1,124 @@
+package org.egov.batchtelemetry.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import lombok.extern.slf4j.Slf4j;
+import org.egov.batchtelemetry.config.AppProperties;
+import org.egov.batchtelemetry.constants.TelemetryConstants;
+import org.egov.batchtelemetry.models.InputNode;
+import org.egov.batchtelemetry.models.InputPath;
+import org.egov.batchtelemetry.models.Node;
+import org.egov.batchtelemetry.producer.Producer;
+import org.egov.batchtelemetry.util.URLComparator;
+import org.json.JSONObject;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+@Slf4j
+public class PathProcessor {
+
+    private ObjectMapper mapper;
+    private String kafkaTopic;
+    private Producer producer;
+    private Configuration configuration;
+
+
+    private List<InputPath> inputPaths;
+
+    public PathProcessor(AppProperties appProperties) {
+
+        mapper = new ObjectMapper();
+        producer = new Producer();
+        kafkaTopic = appProperties.getOutputKafkaTopic();
+        configuration = Configuration.defaultConfiguration().addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS);
+
+        inputPaths = new ArrayList<>();
+
+        initPaths();
+    }
+
+    private void initPaths() {
+        List<InputNode> inputNodes;
+
+        inputNodes = new ArrayList<>();
+        inputNodes.add(InputNode.builder().nodeName("/citizen/user/login").url("/citizen/user/login").build());
+        inputNodes.add(InputNode.builder().nodeName("/citizen/user/otp").url("/citizen/user/otp").build());
+        inputNodes.add(InputNode.builder().nodeName("/citizen").url("/citizen").build());
+
+        inputPaths.add(InputPath.builder().pathId("path-1").inputNodes(inputNodes).build());
+
+        inputNodes = new ArrayList<>();
+        inputNodes.add(InputNode.builder().nodeName("/citizen").url("/citizen").build());
+        inputNodes.add(InputNode.builder().nodeName("/citizen/property-tax").url("/citizen/property-tax").build());
+
+        inputPaths.add(InputPath.builder().pathId("path-2").inputNodes(inputNodes).build());
+    }
+
+
+    public void findAndPushPaths(List<Map<String, Object>> sessionContent, String sessionId) {
+//        log.info("Finding paths for sessionId : " + sessionId);
+        List<Map<String, Object>> summaryEvents = new ArrayList<>();
+        for(Map<String, Object> event : sessionContent) {
+            String jsonRecord = new JSONObject(event).toString();
+            if("SUMMARY".equalsIgnoreCase(JsonPath.using(configuration).parse(jsonRecord).read("$.eid"))) {
+                summaryEvents.add(event);
+            }
+        }
+
+        for(InputPath inputPath : inputPaths) {
+            checkForPath(summaryEvents, inputPath, sessionId);
+        }
+    }
+
+    public void checkForPath(List<Map<String, Object>> summaryEvents, InputPath inputPath, String sessionId) {
+        int nodePointer = 0;
+        for(int eventPointer = 0; eventPointer < summaryEvents.size(); eventPointer++) {
+
+            String event = new JSONObject(summaryEvents.get(eventPointer)).toString();
+            String eventURL = JsonPath.using(configuration).parse(event).read("$.edata.url");
+            if(eventURL == null)
+                continue;
+
+            InputNode inputNode = inputPath.getInputNodes().get(nodePointer);
+            String nodeURL = inputNode.getUrl();
+
+            if(URLComparator.compareURLs(eventURL, nodeURL)) {
+
+                String nodeId = UUID.randomUUID().toString();
+                Long timestamp = JsonPath.using(configuration).parse(event).read("$.ets");
+                Long timeSpent = Long.valueOf(JsonPath.using(configuration).parse(event).read("$.edata.timeSpent").toString());
+
+                Node node = Node.builder().type(TelemetryConstants.pathTypeName).nodeId(nodeId).pathId(inputPath.getPathId())
+                        .sessionId(sessionId).nodeName(inputNode.getNodeName()).url(inputNode.getUrl()).nodeTime(timestamp)
+                        .timeSpent(timeSpent).timestamp(getTimestamp(timestamp)).build();
+                pushNodeDetails(node);
+
+                nodePointer++;
+                if(nodePointer == inputPath.getInputNodes().size())
+                    nodePointer = 0;
+
+            } else if(nodePointer > 0 && URLComparator.compareURLs(eventURL, inputPath.getInputNodes()
+                    .get(nodePointer - 1).getUrl())) {
+                continue;
+            } else {
+                nodePointer = 0;
+            }
+        }
+    }
+
+    private static String getTimestamp(Long timestamp) {
+        Date date = new Date(Long.valueOf(timestamp));
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return formatter.format(date);
+    }
+
+    private void pushNodeDetails(Node node) {
+        JsonNode jsonNode = mapper.valueToTree(node);
+        producer.push(kafkaTopic, node.getNodeId(), node.getNodeTime(), jsonNode);
+    }
+}

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/util/SessionIterator.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/util/SessionIterator.java
@@ -24,7 +24,7 @@ public class SessionIterator implements Iterator<List<Map<String, Object>>> {
         sortedRecords = sortRecords(getRecords());
     }
 
-    protected static List<Map<String, Object>> sortRecords(List<Map<String, Object>> jsonArray) {
+    private static List<Map<String, Object>> sortRecords(List<Map<String, Object>> jsonArray) {
 
         Collections.sort(jsonArray, new Comparator<Map<String, Object>>() {
             @Override
@@ -50,7 +50,7 @@ public class SessionIterator implements Iterator<List<Map<String, Object>>> {
         return jsonArray;
     }
 
-    protected List<Map<String, Object>> getRecords() {
+    private List<Map<String, Object>> getRecords() {
         List<Map<String, Object>> jsonArray = new ArrayList<>();
 
         while (deviceReocrds.hasNext()) {
@@ -88,6 +88,8 @@ public class SessionIterator implements Iterator<List<Map<String, Object>>> {
         return sessionContent;
     }
 
+    //Multiple users in same session
+    //Needs revisit here
     private boolean checkForUserChange(Map<String, Object> record, Map<String, Object> nextRecord) {
         String user1 = (String) ( (Map<String, Object>) record.get("actor")).get("id");
         String user2 = (String) ( (Map<String, Object>) nextRecord.get("actor")).get("id");
@@ -95,9 +97,11 @@ public class SessionIterator implements Iterator<List<Map<String, Object>>> {
         if(user1.equalsIgnoreCase(TelemetryConstants.userNotFoundIdentifier) ||
                 user2.equalsIgnoreCase(TelemetryConstants.userNotFoundIdentifier)) {
             return false;
+        } else if(user1.equalsIgnoreCase(user2)) {
+            return false;
         }
 
-        return false;
+        return true;
     }
 
     private boolean checkForTimeout(Map<String, Object> record, Map<String, Object> nextRecord) {

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/util/URLComparator.java
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/java/org/egov/batchtelemetry/util/URLComparator.java
@@ -1,0 +1,14 @@
+package org.egov.batchtelemetry.util;
+
+public class URLComparator {
+
+    public static boolean compareURLs(String url, String checkFor) {
+
+        if(url.contains(checkFor)) {
+            if (url.length() - url.indexOf(checkFor) <= checkFor.length() + 2) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/egov-telemetry/egov-telemetry-batch-process/src/main/resources/application.properties
+++ b/core/egov-telemetry/egov-telemetry-batch-process/src/main/resources/application.properties
@@ -18,5 +18,5 @@ ES_NODE_WAN_ONLY=false
 
 #-------------------Elasticsearch Telemetry index name config----------------------#
 ES_INPUT_TELEMETRY_INDEX=egovtelemetryreindex*/general/
-ES_OUTPUT_TELEMETRY_BATCH_INDEX=batch-telemetry*/general/
+ES_OUTPUT_TELEMETRY_BATCH_INDEX=batchtelemetryindex-v1*/general/
 

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/Main.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/Main.java
@@ -4,8 +4,10 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.egov.telemetry.config.AppProperties;
 import org.egov.telemetry.deduplicator.TelemetryDeduplicator;
+import org.egov.telemetry.enrich.TelemetryEnrichMessages;
 import org.egov.telemetry.formatchecker.TelemetryFormatChecker;
 import org.egov.telemetry.sink.TelemetryFinalStream;
+import org.egov.telemetry.unbundle.TelemetryUnbundleBatches;
 
 import java.util.Properties;
 
@@ -27,9 +29,17 @@ public class Main {
         TelemetryDeduplicator telemetryDeduplicator = new TelemetryDeduplicator();
         telemetryDeduplicator.shouldRemoveDuplicatesFromTheInput(streamsConfiguration, appProperties.getTelemetryValidatedMessages(), appProperties.getTelemetryDedupedMessages(), appProperties.getDeDupStorageTime());
 
-        TelemetryFinalStream telemetryFinalStream = new TelemetryFinalStream();
-        telemetryFinalStream.pushFinalMessages(streamsConfiguration, appProperties.getTelemetryDedupedMessages(), appProperties.getTelemetryFinalMessages());
+        TelemetryUnbundleBatches telemetryUnbundleBatches = new TelemetryUnbundleBatches();
+        telemetryUnbundleBatches.unbundleBatches(streamsConfiguration, appProperties.getTelemetryDedupedMessages(),
+                appProperties.getTelemetryUnbundledMessages());
 
+        TelemetryEnrichMessages telemetryEnrichMessages = new TelemetryEnrichMessages();
+        telemetryEnrichMessages.enrichMessages(streamsConfiguration, appProperties.getTelemetryUnbundledMessages(),
+                appProperties.getTelemetryEnrichedMessages());
+
+        TelemetryFinalStream telemetryFinalStream = new TelemetryFinalStream();
+        telemetryFinalStream.pushFinalMessages(streamsConfiguration, appProperties.getTelemetryEnrichedMessages(),
+                appProperties.getTelemetryFinalMessages());
     }
 
     private static void checkIfFilesExists() throws Exception {

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/Main.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/Main.java
@@ -20,7 +20,7 @@ public class Main {
 
         Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, appProperties.getKafkaBootstrapServerConfig());
-        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
 
 
         TelemetryFormatChecker telemetryFormatChecker = new TelemetryFormatChecker();
@@ -28,6 +28,10 @@ public class Main {
 
         TelemetryDeduplicator telemetryDeduplicator = new TelemetryDeduplicator();
         telemetryDeduplicator.shouldRemoveDuplicatesFromTheInput(streamsConfiguration, appProperties.getTelemetryValidatedMessages(), appProperties.getTelemetryDedupedMessages(), appProperties.getDeDupStorageTime());
+
+        TelemetryFinalStream telemetryFinalStream = new TelemetryFinalStream();
+        telemetryFinalStream.pushFinalMessages(streamsConfiguration, appProperties.getTelemetryDedupedMessages(),
+                appProperties.getTelemetrySecorFinalMessages());
 
         TelemetryUnbundleBatches telemetryUnbundleBatches = new TelemetryUnbundleBatches();
         telemetryUnbundleBatches.unbundleBatches(streamsConfiguration, appProperties.getTelemetryDedupedMessages(),
@@ -37,9 +41,9 @@ public class Main {
         telemetryEnrichMessages.enrichMessages(streamsConfiguration, appProperties.getTelemetryUnbundledMessages(),
                 appProperties.getTelemetryEnrichedMessages());
 
-        TelemetryFinalStream telemetryFinalStream = new TelemetryFinalStream();
         telemetryFinalStream.pushFinalMessages(streamsConfiguration, appProperties.getTelemetryEnrichedMessages(),
-                appProperties.getTelemetryFinalMessages());
+                appProperties.getTelemetryElasticsearchFinalMessages());
+
     }
 
     private static void checkIfFilesExists() throws Exception {

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/config/AppProperties.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/config/AppProperties.java
@@ -23,7 +23,9 @@ public class AppProperties {
     @Getter
     private String telemetryEnrichedMessages;
     @Getter
-    private String telemetryFinalMessages;
+    private String telemetrySecorFinalMessages;
+    @Getter
+    private String telemetryElasticsearchFinalMessages;
     @Getter
     private Integer deDupStorageTime; //In Minutes
 
@@ -35,7 +37,8 @@ public class AppProperties {
         telemetryDedupedMessages = System.getenv("TELEMETRY_DEDUPED_MESSAGES");
         telemetryUnbundledMessages = System.getenv("TELEMETRY_UNBUNDLED_MESSAGES");
         telemetryEnrichedMessages = System.getenv("TELEMETRY_ENRICHED_MESSAGES");
-        telemetryFinalMessages = System.getenv("TELEMETRY_FINAL_MESSAGES");
+        telemetrySecorFinalMessages = System.getenv("TELEMETRY_SECOR_FINAL_MESSAGES");
+        telemetryElasticsearchFinalMessages = System.getenv("TELEMETRY_ELASTICSEARCH_FINAL_MESSAGES");
 
         if(System.getenv("DEDUP_STORAGE_TIME") != null)
             deDupStorageTime = Integer.parseInt(System.getenv("DEDUP_STORAGE_TIME"));
@@ -65,8 +68,11 @@ public class AppProperties {
         if(telemetryEnrichedMessages == null)
             telemetryEnrichedMessages = properties.getProperty("TELEMETRY_ENRICHED_MESSAGES");
 
-        if(telemetryFinalMessages == null)
-            telemetryFinalMessages = properties.getProperty("TELEMETRY_FINAL_MESSAGES");
+        if(telemetrySecorFinalMessages == null)
+            telemetrySecorFinalMessages = properties.getProperty("TELEMETRY_SECOR_FINAL_MESSAGES");
+
+        if(telemetryElasticsearchFinalMessages == null)
+            telemetryElasticsearchFinalMessages = properties.getProperty("TELEMETRY_ELASTICSEARCH_FINAL_MESSAGES");
 
         if(deDupStorageTime == null)
             if(properties.getProperty("DEDUP_STORAGE_TIME") != null)

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/config/AppProperties.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/config/AppProperties.java
@@ -19,6 +19,10 @@ public class AppProperties {
     @Getter
     private String telemetryDedupedMessages;
     @Getter
+    private String telemetryUnbundledMessages;
+    @Getter
+    private String telemetryEnrichedMessages;
+    @Getter
     private String telemetryFinalMessages;
     @Getter
     private Integer deDupStorageTime; //In Minutes
@@ -29,36 +33,44 @@ public class AppProperties {
         telemetryRawInput = System.getenv("TELEMETRY_RAW_INPUT");
         telemetryValidatedMessages = System.getenv("TELEMETRY_VALIDATED_MESSAGES");
         telemetryDedupedMessages = System.getenv("TELEMETRY_DEDUPED_MESSAGES");
+        telemetryUnbundledMessages = System.getenv("TELEMETRY_UNBUNDLED_MESSAGES");
+        telemetryEnrichedMessages = System.getenv("TELEMETRY_ENRICHED_MESSAGES");
         telemetryFinalMessages = System.getenv("TELEMETRY_FINAL_MESSAGES");
 
         if(System.getenv("DEDUP_STORAGE_TIME") != null)
             deDupStorageTime = Integer.parseInt(System.getenv("DEDUP_STORAGE_TIME"));
 
-//        Properties properties = new Properties();
-//        try {
-//            properties.load(getClass().getClassLoader().getResourceAsStream("application.properties"));
-//        } catch (IOException e) {
-//            log.error("application.properties not found");
-//        }
-//
-//        if(kafkaBootstrapServerConfig == null)
-//          kafkaBootstrapServerConfig = properties.getProperty("BOOTSTRAP_SERVER_CONFIG");
-//
-//        if(telemetryRawInput == null)
-//            telemetryRawInput = properties.getProperty("TELEMETRY_RAW_INPUT");
-//
-//        if(telemetryValidatedMessages == null)
-//            telemetryValidatedMessages = properties.getProperty("TELEMETRY_VALIDATED_MESSAGES");
-//
-//        if(telemetryDedupedMessages == null)
-//            telemetryDedupedMessages = properties.getProperty("TELEMETRY_DEDUPED_MESSAGES");
-//
-//        if(telemetryFinalMessages == null)
-//            telemetryFinalMessages = properties.getProperty("TELEMETRY_FINAL_MESSAGES");
-//
-//        if(deDupStorageTime == null)
-//            if(properties.getProperty("DEDUP_STORAGE_TIME") != null)
-//                deDupStorageTime = Integer.parseInt(properties.getProperty("DEDUP_STORAGE_TIME"));
+        Properties properties = new Properties();
+        try {
+            properties.load(getClass().getClassLoader().getResourceAsStream("application.properties"));
+        } catch (IOException e) {
+            log.error("application.properties not found");
+        }
+
+        if(kafkaBootstrapServerConfig == null)
+          kafkaBootstrapServerConfig = properties.getProperty("BOOTSTRAP_SERVER_CONFIG");
+
+        if(telemetryRawInput == null)
+            telemetryRawInput = properties.getProperty("TELEMETRY_RAW_INPUT");
+
+        if(telemetryValidatedMessages == null)
+            telemetryValidatedMessages = properties.getProperty("TELEMETRY_VALIDATED_MESSAGES");
+
+        if(telemetryDedupedMessages == null)
+            telemetryDedupedMessages = properties.getProperty("TELEMETRY_DEDUPED_MESSAGES");
+
+        if(telemetryUnbundledMessages == null)
+            telemetryUnbundledMessages = properties.getProperty("TELEMETRY_UNBUNDLED_MESSAGES");
+
+        if(telemetryEnrichedMessages == null)
+            telemetryEnrichedMessages = properties.getProperty("TELEMETRY_ENRICHED_MESSAGES");
+
+        if(telemetryFinalMessages == null)
+            telemetryFinalMessages = properties.getProperty("TELEMETRY_FINAL_MESSAGES");
+
+        if(deDupStorageTime == null)
+            if(properties.getProperty("DEDUP_STORAGE_TIME") != null)
+                deDupStorageTime = Integer.parseInt(properties.getProperty("DEDUP_STORAGE_TIME"));
 
     }
 

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/deduplicator/TelemetryDeduplicator.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/deduplicator/TelemetryDeduplicator.java
@@ -163,7 +163,9 @@ public class TelemetryDeduplicator {
         deduplicated.to(outputTopic);
 
         KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.cleanUp();
         streams.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
 
     }
 

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/enrich/TelemetryEnrichMessages.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/enrich/TelemetryEnrichMessages.java
@@ -1,0 +1,66 @@
+package org.egov.telemetry.enrich;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.json.JSONObject;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.TimeZone;
+
+@Slf4j
+public class TelemetryEnrichMessages {
+
+    private String getOutputKey(JSONObject jsonObject) {
+        return jsonObject.getString("mid");
+    }
+
+    private Long getTimestamp(JSONObject jsonObject) {
+        return jsonObject.getLong("ets");
+    }
+
+    private void addTimestampToMessage(JSONObject jsonObject) {
+        Date date = new Date(Long.valueOf(getTimestamp(jsonObject)));
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        jsonObject.put("@timestamp", formatter.format(date));
+    }
+
+    public void enrichMessages(Properties streamsConfiguration, String inputTopic, String outputTopic) {
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "message-enrich");
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+                TelemetryEventTimestampExtractor.class);
+
+        StreamsBuilder builder = new StreamsBuilder();
+
+        KStream<String, String> inputStream = builder.stream(inputTopic);
+
+        inputStream.map(new KeyValueMapper<String, String, KeyValue<?, ?>>() {
+            @Override
+            public KeyValue<?, ?> apply(String key, String value) {
+                JSONObject jsonObject = new JSONObject(value);
+                String outputKey = getOutputKey(jsonObject);
+                addTimestampToMessage(jsonObject);
+                return KeyValue.pair(outputKey, jsonObject.toString());
+            }
+        }).to(outputTopic);
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.cleanUp();
+        streams.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
+
+    }
+
+}
+

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/enrich/TelemetryEventTimestampExtractor.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/enrich/TelemetryEventTimestampExtractor.java
@@ -1,0 +1,31 @@
+package org.egov.telemetry.enrich;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.json.JSONObject;
+
+@Slf4j
+public class TelemetryEventTimestampExtractor implements TimestampExtractor {
+
+    Configuration configuration;
+
+    public TelemetryEventTimestampExtractor() {
+        configuration = Configuration.defaultConfiguration().addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL,
+                Option.SUPPRESS_EXCEPTIONS);
+    }
+
+    private Long getTimestamp(JSONObject jsonObject) {
+        return jsonObject.getLong("ets");
+    }
+
+    @Override
+    public long extract(ConsumerRecord<Object, Object> record, long previousTimestamp) {
+        JSONObject jsonObject = new JSONObject( (String) record.value());
+        return getTimestamp(jsonObject);
+    }
+
+}

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/sink/TelemetryFinalStream.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/sink/TelemetryFinalStream.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 public class TelemetryFinalStream {
 
     public void pushFinalMessages(Properties streamsConfiguration, String inputTopic, String outputTopic) {
-        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "push-final-messages");
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "push-" + outputTopic);
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
 
@@ -26,7 +26,7 @@ public class TelemetryFinalStream {
         inputStream.mapValues(new ValueMapper<String, String>() {
             @Override
             public String apply(String value) {
-                log.info("Message pushed to telemetry-final-messages");
+                log.info("Message pushed to " + outputTopic);
                 return value;
             }
         }).to(outputTopic);

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/unbundle/TelemetryUnbundleBatches.java
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/java/org/egov/telemetry/unbundle/TelemetryUnbundleBatches.java
@@ -1,21 +1,22 @@
-package org.egov.telemetry.sink;
+package org.egov.telemetry.unbundle;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
+public class TelemetryUnbundleBatches {
 
-@Slf4j
-public class TelemetryFinalStream {
-
-    public void pushFinalMessages(Properties streamsConfiguration, String inputTopic, String outputTopic) {
-        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "push-final-messages");
+    public void unbundleBatches(Properties streamsConfiguration, String inputTopic, String outputTopic) {
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "message-unbundle");
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
 
@@ -23,13 +24,20 @@ public class TelemetryFinalStream {
 
         KStream<String, String> inputStream = builder.stream(inputTopic);
 
-        inputStream.mapValues(new ValueMapper<String, String>() {
+        inputStream.flatMapValues(new ValueMapper<String, Iterable<?>>() {
             @Override
-            public String apply(String value) {
-                log.info("Message pushed to telemetry-final-messages");
-                return value;
+            public Iterable<?> apply(String value) {
+                JSONObject jsonObject = new JSONObject(value);
+                JSONArray jsonArray = jsonObject.getJSONArray("events");
+                List<String> events = new ArrayList<>();
+                for(Object object : jsonArray) {
+                    JSONObject jsonObject1 = (JSONObject) object;
+                    events.add(jsonObject1.toString());
+                }
+                return events;
             }
         }).to(outputTopic);
+
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
         streams.cleanUp();

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/resources/application.properties
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/resources/application.properties
@@ -9,7 +9,9 @@ TELEMETRY_DEDUPED_MESSAGES=telemetry-deduped-messages
 TELEMETRY_UNBUNDLED_MESSAGES=telemetry-unbundled-messages
 TELEMETRY_ENRICHED_MESSAGES=telemetry-enriched-messages
 
-TELEMETRY_FINAL_MESSAGES=telemetry-final-messages
+TELEMETRY_SECOR_FINAL_MESSAGES=telemetry-final-messages
+
+TELEMETRY_ELASTICSEARCH_FINAL_MESSAGES=telemetry-es-final-messages
 
 #Storage Time for Deduplication (in Minutes)
 DEDUP_STORAGE_TIME=60

--- a/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/resources/application.properties
+++ b/core/egov-telemetry/egov-telemetry-kafka-streams/src/main/resources/application.properties
@@ -5,6 +5,10 @@ BOOTSTRAP_SERVER_CONFIG=localhost:9092
 TELEMETRY_RAW_INPUT=telemetry-raw-input
 TELEMETRY_VALIDATED_MESSAGES=telemetry-validated-messages
 TELEMETRY_DEDUPED_MESSAGES=telemetry-deduped-messages
+
+TELEMETRY_UNBUNDLED_MESSAGES=telemetry-unbundled-messages
+TELEMETRY_ENRICHED_MESSAGES=telemetry-enriched-messages
+
 TELEMETRY_FINAL_MESSAGES=telemetry-final-messages
 
 #Storage Time for Deduplication (in Minutes)


### PR DESCRIPTION
Changes to the Telemetry Kafka Streams program to add functionality of unbundling and message enrichment. These were being done in egov-indexer. Now kafka-connect elasticsearch sink can be configured to pick messages from "telemetry-es-final-messages" (topic) and index them directly on elasticsearch.

It will need changes to the environment variables.