### PR TITLE
Fix regular expressions

### DIFF
--- a/npm-modules/asset/lib/master/assetImmovableView.js
+++ b/npm-modules/asset/lib/master/assetImmovableView.js
@@ -119,7 +119,7 @@ class assetImmovableView extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/npm-modules/asset/lib/master/assetMovableView.js
+++ b/npm-modules/asset/lib/master/assetMovableView.js
@@ -119,7 +119,7 @@ class assetMovableView extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/npm-modules/ui-react-framework/lib/view.js
+++ b/npm-modules/ui-react-framework/lib/view.js
@@ -47,7 +47,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/npm-modules/works/lib/transaction/viewAbstractEstimate.js
+++ b/npm-modules/works/lib/transaction/viewAbstractEstimate.js
@@ -42,7 +42,7 @@ class viewAbstractEstimate extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/framework/createPt.js
+++ b/web/react-pgr-web/src/components/framework/createPt.js
@@ -91,7 +91,7 @@ class Report extends Component {
         var arr = _.get(_form, specs[moduleName + "." + actionName].groups[i].jsonPath);
         ind = i;
         var _stringifiedGroup = JSON.stringify(specs[moduleName + "." + actionName].groups[i]);
-        var regex = new RegExp(specs[moduleName + "." + actionName].groups[i].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+        var regex = new RegExp(specs[moduleName + "." + actionName].groups[i].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
         for(var j=1; j < arr.length; j++) {
           i++;
           specs[moduleName + "." + actionName].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, specs[moduleName + "." + actionName].groups[ind].jsonPath + "[" + j + "]")));

--- a/web/react-pgr-web/src/components/framework/createPt.js
+++ b/web/react-pgr-web/src/components/framework/createPt.js
@@ -67,7 +67,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/framework/inbox - Copy.js
+++ b/web/react-pgr-web/src/components/framework/inbox - Copy.js
@@ -252,7 +252,7 @@ class Inbox extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/framework/view.js
+++ b/web/react-pgr-web/src/components/framework/view.js
@@ -49,7 +49,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]"") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/asset/master/assetImmovableView.js
+++ b/web/react-pgr-web/src/components/non-framework/asset/master/assetImmovableView.js
@@ -127,7 +127,7 @@ class assetImmovableView extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/asset/master/assetMovableView.js
+++ b/web/react-pgr-web/src/components/non-framework/asset/master/assetMovableView.js
@@ -127,7 +127,7 @@ class assetMovableView extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/citizenServices/buildingPlan/view.js
+++ b/web/react-pgr-web/src/components/non-framework/citizenServices/buildingPlan/view.js
@@ -68,7 +68,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/citizenServices/tl/view.js
+++ b/web/react-pgr-web/src/components/non-framework/citizenServices/tl/view.js
@@ -66,7 +66,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/citizenServices/wc/view.js
+++ b/web/react-pgr-web/src/components/non-framework/citizenServices/wc/view.js
@@ -69,7 +69,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\[/g, "\\[") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/citizenServices/wc/view.js
+++ b/web/react-pgr-web/src/components/non-framework/citizenServices/wc/view.js
@@ -69,7 +69,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\[/g, "\\[") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/pt/viewDCB.js
+++ b/web/react-pgr-web/src/components/non-framework/pt/viewDCB.js
@@ -51,7 +51,7 @@ class ViewDCB extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/tl/masters/view/viewPenaltyRates.js
+++ b/web/react-pgr-web/src/components/non-framework/tl/masters/view/viewPenaltyRates.js
@@ -125,7 +125,7 @@ class viewPenaltyRates extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/tl/masters/viewFeeMatrix.js
+++ b/web/react-pgr-web/src/components/non-framework/tl/masters/viewFeeMatrix.js
@@ -125,7 +125,7 @@ class viewFeeMatrix extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/tl/transaction/viewLegacyLicense.js
+++ b/web/react-pgr-web/src/components/non-framework/tl/transaction/viewLegacyLicense.js
@@ -123,7 +123,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/wc/viewLegacy.js
+++ b/web/react-pgr-web/src/components/non-framework/wc/viewLegacy.js
@@ -48,7 +48,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\[/g, "\\[") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/wc/viewLegacy.js
+++ b/web/react-pgr-web/src/components/non-framework/wc/viewLegacy.js
@@ -48,7 +48,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\[/g, "\\[") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/wc/viewWc.js
+++ b/web/react-pgr-web/src/components/non-framework/wc/viewWc.js
@@ -122,7 +122,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/works/transaction/abstractEstimate/viewAbstractEstimate.js
+++ b/web/react-pgr-web/src/components/non-framework/works/transaction/abstractEstimate/viewAbstractEstimate.js
@@ -46,7 +46,7 @@ class viewAbstractEstimate extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/react-pgr-web/src/components/non-framework/works/transaction/spilloverAE/viewSpilloverAE.js
+++ b/web/react-pgr-web/src/components/non-framework/works/transaction/spilloverAE/viewSpilloverAE.js
@@ -46,7 +46,7 @@ class viewSpilloverAE extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/framework/createPt.js
+++ b/web/ui-web-app/src/components/framework/createPt.js
@@ -91,7 +91,7 @@ class Report extends Component {
         var arr = _.get(_form, specs[moduleName + "." + actionName].groups[i].jsonPath);
         ind = i;
         var _stringifiedGroup = JSON.stringify(specs[moduleName + "." + actionName].groups[i]);
-        var regex = new RegExp(specs[moduleName + "." + actionName].groups[i].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+        var regex = new RegExp(specs[moduleName + "." + actionName].groups[i].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
         for(var j=1; j < arr.length; j++) {
           i++;
           specs[moduleName + "." + actionName].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, specs[moduleName + "." + actionName].groups[ind].jsonPath + "[" + j + "]")));

--- a/web/ui-web-app/src/components/framework/createPt.js
+++ b/web/ui-web-app/src/components/framework/createPt.js
@@ -67,7 +67,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/framework/inbox - Copy.js
+++ b/web/ui-web-app/src/components/framework/inbox - Copy.js
@@ -252,7 +252,7 @@ class Inbox extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/framework/view.js
+++ b/web/ui-web-app/src/components/framework/view.js
@@ -48,7 +48,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/citizenServices/buildingPlan/view.js
+++ b/web/ui-web-app/src/components/non-framework/citizenServices/buildingPlan/view.js
@@ -68,7 +68,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/citizenServices/tl/view.js
+++ b/web/ui-web-app/src/components/non-framework/citizenServices/tl/view.js
@@ -66,7 +66,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/citizenServices/wc/view.js
+++ b/web/ui-web-app/src/components/non-framework/citizenServices/wc/view.js
@@ -69,7 +69,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/pt/viewDCB.js
+++ b/web/ui-web-app/src/components/non-framework/pt/viewDCB.js
@@ -51,7 +51,7 @@ class ViewDCB extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/tl/masters/view/viewPenaltyRates.js
+++ b/web/ui-web-app/src/components/non-framework/tl/masters/view/viewPenaltyRates.js
@@ -125,7 +125,7 @@ class viewPenaltyRates extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\[/g, "\\[") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/tl/masters/view/viewPenaltyRates.js
+++ b/web/ui-web-app/src/components/non-framework/tl/masters/view/viewPenaltyRates.js
@@ -125,7 +125,7 @@ class viewPenaltyRates extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\[/g, "\\[") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/tl/masters/viewFeeMatrix.js
+++ b/web/ui-web-app/src/components/non-framework/tl/masters/viewFeeMatrix.js
@@ -125,7 +125,7 @@ class viewFeeMatrix extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/tl/transaction/viewLegacyLicense.js
+++ b/web/ui-web-app/src/components/non-framework/tl/transaction/viewLegacyLicense.js
@@ -123,7 +123,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/wc/viewLegacy.js
+++ b/web/ui-web-app/src/components/non-framework/wc/viewLegacy.js
@@ -48,7 +48,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/components/non-framework/wc/viewWc.js
+++ b/web/ui-web-app/src/components/non-framework/wc/viewWc.js
@@ -122,7 +122,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/development/asset/lib/master/assetImmovableView.js
+++ b/web/ui-web-app/src/development/asset/lib/master/assetImmovableView.js
@@ -119,7 +119,7 @@ class assetImmovableView extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/development/asset/lib/master/assetMovableView.js
+++ b/web/ui-web-app/src/development/asset/lib/master/assetMovableView.js
@@ -119,7 +119,7 @@ class assetMovableView extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/development/ui-react-framework/lib/view.js
+++ b/web/ui-web-app/src/development/ui-react-framework/lib/view.js
@@ -47,7 +47,7 @@ class Report extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));

--- a/web/ui-web-app/src/development/works/lib/transaction/viewAbstractEstimate.js
+++ b/web/ui-web-app/src/development/works/lib/transaction/viewAbstractEstimate.js
@@ -42,7 +42,7 @@ class viewAbstractEstimate extends Component {
           var arr = _.get(_form, children[i].groups[j].jsonPath);
           var ind = j;
           var _stringifiedGroup = JSON.stringify(children[i].groups[j]);
-          var regex = new RegExp(children[i].groups[j].jsonPath.replace("[", "\[").replace("]", "\]") + "\\[\\d{1}\\]", 'g');
+          var regex = new RegExp(children[i].groups[j].jsonPath.replace(/\[/g, "\\[").replace(/\]/g, "\\]") + "\\[\\d{1}\\]", 'g');
           for(var k=1; k < arr.length; k++) {
             j++;
             children[i].groups[j].groups.splice(ind+1, 0, JSON.parse(_stringifiedGroup.replace(regex, children[i].groups[ind].jsonPath + "[" + k + "]")));


### PR DESCRIPTION
My company is working on automated mistakes detection ([link](https://lgtm.com/projects/g/egovernments/egov-services/overview/)). When looking at our results for regular expressions, I noticed that there's a regular expression in your code base that doesn't do what it's supposed to:

`.replace("[", "\[")` _should_ replace braces by escaped braces. But it doesn't do anything because the `\` isn't escaped in the string itself. Also, since it's missing the global flag, it will only check one occurrance per string.

So I replaced it by `.replace(/\[/g, "\\[")`. (And the same for `replace("]", "\]")` to `.replace(/\]/g, "\\]")`.)

Those RegExes appear a couple of times in the code base, in the functions `setInitialUpdateChildData` and `setInitialUpdateData`.