### PR TITLE
Changed the error message to send the actual error

### DIFF
--- a/core/egov-filestore/src/main/java/org/egov/filestore/persistence/repository/AwsS3Repository.java
+++ b/core/egov-filestore/src/main/java/org/egov/filestore/persistence/repository/AwsS3Repository.java
@@ -162,7 +162,8 @@ public class AwsS3Repository {
 		} catch (Exception ioe) {
 
 			Map<String, String> map = new HashMap<>();
-			map.put("Image Source Invalid", "Image File present in upload request is Invalid/Not Readable");
+			log.error("Exception while uploading the image: ", ioe);
+			map.put("ERROR_AWS_S3_UPLOAD", "An error has occured while trying to upload image to S3 bucket.");
 			throw new CustomException(map);
 		}
 	}


### PR DESCRIPTION
Issue:
Image uploads were failing with the following error - ["code": "Image Source Invalid","message": "Image File present in upload request is Invalid/Not Readable"]
This error says the image is of invalid type, where actually the image is of the correct format but the error is due to the expired AWS key. 

Fix:
Changed the error message to send out the correct error.